### PR TITLE
style(brski): fix `clang-format` issues

### DIFF
--- a/src/brski/brski.cpp
+++ b/src/brski/brski.cpp
@@ -1,8 +1,8 @@
 #include <stdlib.h>
+#include <libgen.h>
 #include <pthread.h>
 #include <string.h>
 #include <unistd.h>
-#include <libgen.h>
 
 #include "registrar/registrar_server.h"
 


### PR DESCRIPTION
Fix clang-format issues in commit https://github.com/nqminds/brski/commit/f6d80a5f869b41c64ad016ece76244226730ecc5 that were causing CI to fail!

Fixed by running `pre-commit run --all`.