### PR TITLE
fix(https_server): fix undeclared `context` error that prevents compilation

### DIFF
--- a/src/brski/http/https_server.cpp
+++ b/src/brski/http/https_server.cpp
@@ -30,7 +30,6 @@ int https_start(struct http_config *config,
   return httplib_start(config, routes, user_ctx, srv_ctx);
 #else
   log_error("No https server defined");
-  https_free_context(*context);
   return -1;
 #endif
 }


### PR DESCRIPTION
Compiling the `https_server.cpp` file fails when `WITH_CPPHTTPLIB_LIB` is not defined.

This is because the `https_free_context` function and `context` vars are not declared, which results in the following error in GCC 11.3.0:

> ```
> /brski/src/brski/http/https_server.cpp: In function ‘int https_start(http_config*, std::vector<RouteTuple>&, void*, void**)’:
> /brski/src/brski/http/https_server.cpp:33:23: error: ‘context’ was not declared in this scope
>    33 |   https_free_context(*context);
>       |                       ^~~~~~~
> /brski/src/brski/http/https_server.cpp:33:3: error: ‘https_free_context’ was not declared in this scope
>    33 |   https_free_context(*context);
> ```

These functions/param were partially removed in commit d484024 (feat: Added registrar/server context to routes, 2023-02-01), but only for the `#ifdef WITH_CPPHTTPLIB_LIB` branch.

Fixes: d4840243ec223ce3ef999cc730e45ca9750bab08

---

**To Reproduce**

- **Compiler**: GCC 11.3.0 (specifically `11.3.0-1ubuntu1~22.04.1`, the current default gcc in Ubuntu 22.04).
- **Commit**: 66c12afd4a7167805a3f56ecd939a12d3bdd97b1 (aka the current `main` branch)

Steps to reproduce the behavior:
1. Configure the project with: `cmake -S . -B build -DUSE_VOUCHER_OPENSSL=ON`.
2. Build with `cmake --build build/ -j` and see the error.
