### PR TITLE
fix(brski): improve the CLI error for a missing `command` arg

### DIFF
--- a/src/brski/brski.cpp
+++ b/src/brski/brski.cpp
@@ -167,6 +167,12 @@ void process_options(int argc, char *argv[], uint8_t *verbosity,
     exit(EXIT_SUCCESS);
   }
 
+  if (command_label == nullptr) {
+    log_cmdline_error("Missing required parameter <command>\n");
+    show_help(argv[0]);
+    exit(EXIT_FAILURE);
+  }
+
   if ((*command_id = get_command_id(command_label)) == COMMAND_UNKNOWN) {
     log_cmdline_error("Unrecognized command \"%s\"\n", command_label);
     exit(EXIT_FAILURE);


### PR DESCRIPTION
Improve the CLI error message that is printed when there is no `<command>`.

### Current behavior

```console
user@pc:~/brski:~/brski (main)$ ./build/src/brski/brski -c ./build/src/brski/dev-config.ini
Command-line usage error: Unrecognized command "(null)"
```

This is pretty confusing, especially as this is a command listed by the `README.md` file, and there's no documentation that the CLI expects a `<command>` argument, see https://github.com/nqminds/brski/issues/11.

### New behavior

I've added an improved error message, and used `show_help()` to show the help text:

```console
user@pc:~/brski (fix/improve-error-for-missing-command)$ ./build/src/brski/brski -c ./build/src/brski/dev-config.ini
Command-line usage error: Missing required parameter <command>brski version 0.2.0-alpha.0
Usage:
	brski [-c filename] [-o filename] [-d] [-h] [-v] <command>

NquiringMinds BRSKI protocol tool.

Show, export and manipulate vouchers. Create registrar and MASA servers.

Commands:
	epvr		Export the pledge voucher request as base64 CMS file
	preq		Send a pledge-voucher request to the registrar
	registrar	Starts the registrar
	masa		Starts the MASA

Options:
	-c filename	 Path to the config file
	-o filename	 Path to the exported file
	-d		 Verbosity level (use multiple -dd... to increase verbosity)
	-h		 Show help
	-v		 Show app version

Copyright Nquiringminds Ltd

```