### PR TITLE
Add a GitHub Action that builds, tests, and installs brski

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,3 +33,17 @@ jobs:
       - name: Install to ${{ runner.temp }}/brski-${{ matrix.cmake-preset }}/
         run: |
           cmake --install "build/${{ matrix.cmake-preset }}" --prefix "${{ runner.temp }}/brski-${{ matrix.cmake-preset }}"
+      - name: Escape invalid chars in artifact name
+        id: escape_preset
+        run: |
+          preset='${{ matrix.cmake-preset }}'
+          # replace `/` with `-`
+          escaped_preset="${preset////-}"
+          echo "::set-output name=ESCAPED_CMAKE_PRESET::${escaped_preset}"
+      - name: Archive Install Output
+        uses: actions/upload-artifact@v3
+        with:
+          name: brski-build-${{ steps.escape_preset.outputs.ESCAPED_CMAKE_PRESET }}
+          retention-days: 7
+          path: |
+            ${{ runner.temp }}/brski-${{ matrix.cmake-preset }}/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,32 @@
+on:
+  push: {}
+  pull_request: {}
+
+name: Build
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        cmake-preset:
+          - linux # normal linux tests
+          - linux-openssl # tests compiling OpenSSL
+          - linux-sanitize
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Cache CMake build/dl folder
+        uses: actions/cache@v3
+        with:
+          path: ./build/dl
+          key: ${{ runner.os }}-${{ matrix.cmake-preset }}-${{ hashFiles( 'lib/*' ) }}
+      - name: Configure
+        run: |
+          cmake --preset "${{ matrix.cmake-preset }}"
+      - name: Build
+        run: |
+          cmake --build --preset "${{ matrix.cmake-preset }}"
+      - name: Test
+        run: |
+          ctest --preset "${{ matrix.cmake-preset }}" --output-on-failure

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,3 +30,6 @@ jobs:
       - name: Test
         run: |
           ctest --preset "${{ matrix.cmake-preset }}" --output-on-failure
+      - name: Install to ${{ runner.temp }}/brski-${{ matrix.cmake-preset }}/
+        run: |
+          cmake --install "build/${{ matrix.cmake-preset }}" --prefix "${{ runner.temp }}/brski-${{ matrix.cmake-preset }}"


### PR DESCRIPTION
This PR adds a GitHub Action that builds, tests, and tests install brski with the following CMake presets:
- `linux`
- `linux-openssl`
- `linux-sanitize`

The installed folder is then uploaded as a GitHub Action artifact, so that we can download the output:

![image](https://github.com/nqminds/brski/assets/19716675/984af4a2-28b6-4df2-ab3b-119d8b8b0b8b)

This should hopefully make your job in reviewing PRs a lot easier (and it also means that contributors don't need to worry about breaking other build presets)
