### PR TITLE
test(brski): expose server on 127.0.0.1 only

### DIFF
--- a/tests/brski/test-config.ini.in
+++ b/tests/brski/test-config.ini.in
@@ -15,7 +15,7 @@ cmsVerifyCertPath = ""
 cmsVerifyStorePath = ""
 
 [registrar]
-bindAddress = "0.0.0.0"
+bindAddress = "127.0.0.1"
 port = 12345
 tlsKeyPath = "@CMAKE_BINARY_DIR@/tests/brski/brski-test-certs/registrar-tls.key"
 tlsCertPath = "@CMAKE_BINARY_DIR@/tests/brski/brski-test-certs/registrar-tls.crt"
@@ -27,7 +27,7 @@ cmsVerifyCertPath = ""
 cmsVerifyStorePath = ""
 
 [masa]
-bindAddress = "0.0.0.0"
+bindAddress = "127.0.0.1"
 port = 12346
 expiresOn = "2030-12-30T00:00:00Z"
 ldevidCAKeyPath = "@CMAKE_BINARY_DIR@/tests/brski/brski-test-certs/ldevid-ca.key"


### PR DESCRIPTION
Run test servers on the `127.0.0.1` IP address only (aka `localhost`), instead of on `0.0.0.0`, which is every IP address.

This prevents the test servers from being accessible on other computers.

_Edit_: Lint errors are unrelated, and will be fixed by https://github.com/nqminds/brski/pull/17