### PR TITLE
build(jsmn): use v1.1.0 of jsmn library

### DIFF
--- a/lib/jsmn.cmake
+++ b/lib/jsmn.cmake
@@ -1,9 +1,10 @@
 if(NOT BUILD_ONLY_DOCS)
   FetchContent_Declare(
     jsmnlib
-    GIT_REPOSITORY https://github.com/zserge/jsmn.git
-    GIT_TAG 25647e692c7906b96ffd2b05ca54c097948e879c
+    URL https://github.com/zserge/jsmn/archive/refs/tags/v1.1.0.tar.gz
+    URL_HASH SHA3_256=f976110eda97a712fa4c99d1f3b396987d0905b2c2f8c7ad32286c15a74368e9
     DOWNLOAD_DIR "${EP_DOWNLOAD_DIR}" # if empty string, uses default download dir
+    DOWNLOAD_NAME jsmn-v1.1.0.tar.gz
   )
   FetchContent_MakeAvailable(jsmnlib)
 


### PR DESCRIPTION
Use [v1.1.0](https://github.com/zserge/jsmn/releases/tag/v1.1.0) of jsmn, instead of a random commit on the jsmn `master` branch.

There's only a 10 commit difference: https://github.com/zserge/jsmn/compare/v1.1.0...25647e692c7906b96ffd2b05ca54c097948e879c

The only major change is https://github.com/zserge/jsmn/commit/23f13d25958f575f293527064cb884cbc3f4c40c, which changed the values of the `jsmntype_t` ENUM.

However, since we're not exposing any jsmn types publically, (jsmn is only used internally in the `src/voucher/voucher.c` file's `deserialize_voucher()` function) this doesn't violate the brski ABI, and we can safely make this change.