### PR TITLE
build: add `BUILD_JSMN` CMake option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * brski tool to demonstrate the Registrar and MASA functionalities
 
+#### Build
+
+* add `BUILD_JSMN` CMake option. Set this to `OFF` in case you want to use
+  your system's [jsmn](https://github.com/zserge/jsmn) lib, instead of
+  downloading it automatically.
+
 ## [0.2.0] - 2023-03-27
 ### Added
 * Voucher artifact implementation as per [RFC8366](https://www.rfc-editor.org/info/rfc8366),

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,7 @@ option(BUILD_ONLY_DOCS "Build only docs" OFF)
 option(BUILD_OPENSSL3_LIB "Build OpenSSL 3" OFF)
 option(BUILD_WOLFSSL_LIB "Build WolfSSL" OFF)
 option(BUILD_LIB_MININI "Builds minIni library" ON)
+option(BUILD_JSMN "Downloads jsmn (if off, use system JSMN lib)" ON)
 option(USE_CPPHTTPLIB_LIB "Build and use the cpp-httplib" OFF)
 
 option(USE_VOUCHER_OPENSSL "Build voucher library with openssl support" OFF)

--- a/lib/jsmn.cmake
+++ b/lib/jsmn.cmake
@@ -1,4 +1,5 @@
-if(NOT BUILD_ONLY_DOCS)
+if(BUILD_ONLY_DOCS)
+elseif(BUILD_JSMN)
   FetchContent_Declare(
     jsmnlib
     URL https://github.com/zserge/jsmn/archive/refs/tags/v1.1.0.tar.gz
@@ -10,4 +11,17 @@ if(NOT BUILD_ONLY_DOCS)
 
   add_library(jsmn::jsmn INTERFACE IMPORTED)
   target_include_directories(jsmn::jsmn INTERFACE "${jsmnlib_SOURCE_DIR}")
+else()
+  find_path(jsmn_INCLUDE_DIR
+    NAMES jsmn.h
+    DOC "Folder that contains the jsmn.h header"
+  )
+  if (jsmn_INCLUDE_DIR STREQUAL "jsmn_INCLUDE_DIR-NOTFOUND")
+    message(FATAL_ERROR
+      "Could not find jsmn_INCLUDE_DIR using the following files: jsmn.h "
+      "You can set -DBUILD_JSMN=ON to automatically download it.")
+  endif()
+  mark_as_advanced(jsmn_INCLUDE_DIR)
+  add_library(jsmn::jsmn INTERFACE IMPORTED)
+  target_include_directories(jsmn::jsmn INTERFACE "${jsmn_INCLUDE_DIR}")
 endif ()


### PR DESCRIPTION
Add the `BUILD_JSMN` CMake option, which can be set to `OFF` in order to use the system [jsmn](https://github.com/zserge/jsmn) library, instead of downloading it automatically.

If we want to create a `.deb`, we should be using the [libjsmn-dev](https://packages.debian.org/sid/libjsmn-dev) package, instead of downloading it ourselves.