### PR TITLE
Add `debian/` config so that we can build a `brski.deb` package

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,3 +47,70 @@ jobs:
           retention-days: 7
           path: |
             ${{ runner.temp }}/brski-${{ matrix.cmake-preset }}/
+
+  build-deb:
+    name: Build Debian Package
+    # building a deb is super slow, but we're a public repo now, so it's free!!
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        architecture: [arm64, amd64]
+        distribution:
+          - jammy # uses libssl3
+    permissions:
+      contents: write # needed for publishing release artifact
+    env:
+      OTHER_MIRROR:
+        deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports ${{ matrix.distribution }} main universe | deb [arch=amd64] http://archive.ubuntu.com/ubuntu ${{ matrix.distribution }} main universe
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Create pbuilder cache dir
+        # The actions/cache action does not have permissions to create the pbuilder
+        # cache folder if it doesn't exist
+        run: sudo mkdir -m777 -p /var/cache/pbuilder/
+      - name: Cache pbuilder base
+        id: cache-pbuilder-base
+        uses: actions/cache@v3
+        with:
+          path: |
+            /var/cache/pbuilder/base.tgz
+          key: ${{ runner.os }}-${{ matrix.distribution }}-${{ matrix.architecture }}
+        # Sometimes the cache step just freezes forever
+        # so put a limit on it so that we can restart it earlier on failure
+        timeout-minutes: 10
+      - name: Set apt mirror
+        # GitHub Actions apt proxy is super unstable
+        # see https://github.com/actions/runner-images/issues/7048
+        run: |
+          # make sure there is a `\t` between URL and `priority:*` attributes
+          printf 'http://azure.archive.ubuntu.com/ubuntu        priority:1\n' | sudo tee /etc/apt/mirrors.txt
+          curl http://mirrors.ubuntu.com/mirrors.txt | sudo tee --append /etc/apt/mirrors.txt
+          sudo sed -i 's/http:\/\/azure.archive.ubuntu.com\/ubuntu\//mirror+file:\/etc\/apt\/mirrors.txt/' /etc/apt/sources.list
+      - name: Install dependencies
+        run: |
+          sudo apt-get update && sudo apt-get install pbuilder debhelper -y
+      - name: Setup pdebuilderrc for cross-compiling
+        env:
+          PBUILDER_RC: |
+            # Enable network access, since `cmake` downloads dependencies
+            USENETWORK=yes
+            # Faster than default, and is requried if we want to do cross-compiling
+            PBUILDERSATISFYDEPENDSCMD="/usr/lib/pbuilder/pbuilder-satisfydepends-apt"
+        run: |
+          echo "$PBUILDER_RC" | sudo tee -a /etc/pbuilderrc
+      - name: Build pbuilder base.tgz
+        if: steps.cache-pbuilder-base.outputs.cache-hit != 'true'
+        run: |
+          sudo pbuilder create --debootstrapopts --variant=buildd --distribution ${{ matrix.distribution }} --mirror "" --othermirror "$OTHER_MIRROR"
+      - name: Build .deb
+        run: |
+          mkdir -p '${{ runner.temp }}/pbuilder/result'
+          pdebuild --buildresult '${{ runner.temp }}/pbuilder/result' --debbuildopts "-us -uc" -- --override-config --distribution ${{ matrix.distribution }} --mirror "" --othermirror "$OTHER_MIRROR" --host-arch ${{ matrix.architecture }}
+      - name: Archive built debs
+        uses: actions/upload-artifact@v3
+        with:
+          name: brski-built-debs
+          retention-days: 7
+          path: |
+            ${{ runner.temp }}/pbuilder/result/*.deb

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * brski tool to demonstrate the Registrar and MASA functionalities
 
+#### Build
+
+* add `BUILD_JSMN` CMake option. Set this to `OFF` in case you want to use
+  your system's [jsmn](https://github.com/zserge/jsmn) lib, instead of
+  downloading it automatically.
+
 ## [0.2.0] - 2023-03-27
 ### Added
 * Voucher artifact implementation as per [RFC8366](https://www.rfc-editor.org/info/rfc8366),

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,7 @@ option(BUILD_ONLY_DOCS "Build only docs" OFF)
 option(BUILD_OPENSSL3_LIB "Build OpenSSL 3" OFF)
 option(BUILD_WOLFSSL_LIB "Build WolfSSL" OFF)
 option(BUILD_LIB_MININI "Builds minIni library" ON)
+option(BUILD_JSMN "Downloads jsmn (if off, use system JSMN lib)" ON)
 option(USE_CPPHTTPLIB_LIB "Build and use the cpp-httplib" OFF)
 
 option(USE_VOUCHER_OPENSSL "Build voucher library with openssl support" OFF)

--- a/debian/brski.install
+++ b/debian/brski.install
@@ -1,0 +1,2 @@
+etc/brski/*
+usr/bin/brski

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,0 +1,5 @@
+brski (0.2.0-1) UNRELEASED; urgency=low
+
+  * Initial release
+
+ -- Alois Klink <alois@nquiringminds.com>  Tue, 13 Jun 2023 15:52:50 +0100

--- a/debian/control
+++ b/debian/control
@@ -3,10 +3,34 @@ Section: net
 Priority: optional
 Maintainer: Alexandru Mereacre <mereacre@nquiringminds.com>
 Build-Depends: debhelper-compat (= 12),
-    git, ca-certificates, cmake (>=3.15.0),
-    libssl-dev,
-    libminini-dev (>=1.2)
+    ca-certificates, cmake (>=3.15.0),
+    libssl-dev (>=3.0.0),
+    libminini-dev (>=1.2),
+    libjsmn-dev (>=1.1.0)
 Standards-Version: 4.5.0
 Homepage: https://github.com/nqminds/brski
 Vcs-Browser: https://github.com/nqminds/brski
 Vcs-Git: https://github.com/nqminds/brski.git
+
+Package: brski
+Architecture: any
+Multi-Arch: foreign
+Depends:
+    ${shlibs:Depends},
+    ${misc:Depends},
+Description: BRSKI protocol MASA, registrar, and pledge implementations.
+ The Bootstrapping Remote Secure Key Infrastructure (BRSKI) protocol provides a
+ solution for secure zero-touch (automated) bootstrap of new (unconfigured)
+ devices that are called "pledges".
+ Pledges have an Initial Device Identifier (IDevID) installed in them at the
+ factory.
+ .
+ For more information on the BRSKI protocol, please check the RFC8995.
+
+Package: libvoucher-dev
+Architecture: any
+Multi-Arch: foreign
+Depends:
+    ${shlibs:Depends},
+    ${misc:Depends},
+Description: BRSKI voucher library.

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,0 +1,99 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: brski
+Upstream-Contact: https://github.com/nqminds/brski
+Source: https://github.com/nqminds/brski
+# Only due to inclusion of lib/netlink code
+License: Expat AND BSD-3-clause AND LGPL-3.0-or-later
+Copyright: 2023, NquiringMinds Ltd.
+
+Files: *
+Copyright: 2023, NquiringMinds Ltd.
+License: Expat
+
+Files: CMakeModules/CodeCoverage.cmake
+Copyright: 2012 - 2017, Lars Bilke
+License: BSD-3-clause
+Source: https://github.com/bilke/cmake-modules/blob/master/CodeCoverage.cmake
+
+Files: CMakeModules/AddCMockaTest.cmake
+Copyright: 2007, Daniel Gollub <dgollub@suse.de>
+           2007-2018, Andreas Schneider <asn@cryptomilk.org>
+           2018, Anderson Toshiyuki Sasaki <ansasaki@redhat.com>
+License: BSD-3-clause
+
+Files: lib/cmocka.cmake
+Copyright: 2020, OLIVIER LE DOEUFF
+License: Expat
+Comment: Taken from https://github.com/OlivierLDff/cmocka-cmake-example/blob/f11cb0eb5ab4b0bde5df400888c5d17b6882bd97/cmake/FetchCMocka.cmake
+
+Files: src/utils/log.*
+Copyright: 2017, rxi
+           2021-2022, NquiringMinds Ltd.
+License: Expat
+
+Files: src/utils/os.*
+Copyright: 2023, NQMCyber Ltd and edgesec contributors.
+License: LGPL-3.0-or-later
+
+License: Expat
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the
+ "Software"), to deal in the Software without restriction, including
+ without limitation the rights to use, copy, modify, merge, publish,
+ distribute, sublicense, and/or sell copies of the Software, and to
+ permit persons to whom the Software is furnished to do so, subject to
+ the following conditions:
+
+ The above copyright notice and this permission notice shall be included
+ in all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+License: BSD-3-clause
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ 3. Neither the name of the University nor the names of its contributors
+    may be used to endorse or promote products derived from this software
+    without specific prior written permission.
+ .
+ THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ SUCH DAMAGE.
+
+License: LGPL-3+
+ This program is free software; you can redistribute it and/or modify it
+ under the terms of the GNU Lesser General Public License as
+ published by the Free Software Foundation; either version 3 of
+ the License, or (at your option) any later version.
+ .
+ This program is distributed in the hope that it will be useful, but
+ WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+ .
+ You should have received a copy of the GNU Lesser General Public
+ License along with this program; if not, see <https://www.gnu.org/licenses/>.
+ .
+ On Debian systems, the full text of the GNU Lesser General Public
+ License version 3 can be found in the file
+ `/usr/share/common-licenses/LGPL-3'.

--- a/debian/libvoucher-dev.install
+++ b/debian/libvoucher-dev.install
@@ -1,0 +1,2 @@
+usr/include/voucher/*.h
+usr/lib/*/libvoucher.*

--- a/debian/rules
+++ b/debian/rules
@@ -1,0 +1,20 @@
+#!/usr/bin/make -f
+# We use debhelper to compile everything
+
+# You must remove unused comment lines for the released package.
+#export DH_VERBOSE = 1
+#export DEB_BUILD_MAINT_OPTIONS = hardening=+all
+#export DEB_CFLAGS_MAINT_APPEND  = -Wall -pedantic
+#export DEB_LDFLAGS_MAINT_APPEND = -Wl,--as-needed
+
+%:
+	dh $@
+
+override_dh_auto_configure:
+	dh_auto_configure -- \
+	     -DCMAKE_LIBRARY_ARCHITECTURE="$(DEB_TARGET_MULTIARCH)" \
+		 -DCMAKE_BUILD_TYPE=Release \
+		 -DUSE_VOUCHER_OPENSSL=ON\
+		 -DBUILD_OPENSSL3_LIB=OFF\
+		 -DUSE_CPPHTTPLIB_LIB=ON\
+		 -DBUILD_JSMN=OFF

--- a/debian/source/local-options
+++ b/debian/source/local-options
@@ -1,0 +1,2 @@
+# Ignore the build/ directory, as this is where non-build files are stored
+tar-ignore = "build"

--- a/lib/jsmn.cmake
+++ b/lib/jsmn.cmake
@@ -1,4 +1,5 @@
-if(NOT BUILD_ONLY_DOCS)
+if(BUILD_ONLY_DOCS)
+elseif(BUILD_JSMN)
   FetchContent_Declare(
     jsmnlib
     URL https://github.com/zserge/jsmn/archive/refs/tags/v1.1.0.tar.gz
@@ -10,4 +11,17 @@ if(NOT BUILD_ONLY_DOCS)
 
   add_library(jsmn::jsmn INTERFACE IMPORTED)
   target_include_directories(jsmn::jsmn INTERFACE "${jsmnlib_SOURCE_DIR}")
+else()
+  find_path(jsmn_INCLUDE_DIR
+    NAMES jsmn.h
+    DOC "Folder that contains the jsmn.h header"
+  )
+  if (jsmn_INCLUDE_DIR STREQUAL "jsmn_INCLUDE_DIR-NOTFOUND")
+    message(FATAL_ERROR
+      "Could not find jsmn_INCLUDE_DIR using the following files: jsmn.h "
+      "You can set -DBUILD_JSMN=ON to automatically download it.")
+  endif()
+  mark_as_advanced(jsmn_INCLUDE_DIR)
+  add_library(jsmn::jsmn INTERFACE IMPORTED)
+  target_include_directories(jsmn::jsmn INTERFACE "${jsmn_INCLUDE_DIR}")
 endif ()


### PR DESCRIPTION
Adds the appropriate files in `debian/` so that we can build a `brski.deb` Debian package.

I've confirmed that we can install and run the `brski-*.deb` on Ubuntu 22.04 Jammy Jellyfish, both on AMD64 and ARM64. I haven't tested the `libvoucher-dev.deb` though.

If you're curious, this is what the `apt info` says:

```console
user@pc:~$ apt info brski
Package: brski
Version: 0.2.0-1
Status: install ok installed
Priority: optional
Section: net
Maintainer: Alexandru Mereacre <mereacre@nquiringminds.com>
Installed-Size: 464 kB
Depends: libc6 (>= 2.34), libgcc-s1 (>= 3.3.1), libssl3 (>= 3.0.0), libstdc++6 (>= 12)
Homepage: https://github.com/nqminds/brski
Download-Size: unknown
APT-Manual-Installed: yes
APT-Sources: /var/lib/dpkg/status
Description: BRSKI protocol MASA, registrar, and pledge implementations.
 The Bootstrapping Remote Secure Key Infrastructure (BRSKI) protocol provides a
 solution for secure zero-touch (automated) bootstrap of new (unconfigured)
 devices that are called "pledges".
 Pledges have an Initial Device Identifier (IDevID) installed in them at the
 factory.
 .
 For more information on the BRSKI protocol, please check the RFC8995.
```

It looks like `brski` only has 4 runtime dependencies! This should make porting to non-Ubuntu platforms a lot easier.

### Things to look at

@mereacre, can you review the `debian/copyright` file and make sure everything in it is okay?
One thing I've noticed is that since the `src/utils/os.*` files are LGPL-3.0-or-later, it makes the entire BRSKI library/executable LGPL-3.0-or-later too.