### PR TITLE
Allow setting an absolute value for the "Not After" field in certificates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * brski tool to demonstrate the Registrar and MASA functionalities
 
+#### voucher
+
+* add `not_after_absolute` field to `struct crypto_cert_meta`.
+  Unlike the existing `not_after` field, which represents an offset from the
+  current time, the `not_after_absolute` field represents an absolute time.
+  It can be set to `"99991231235959Z"` for a
+  [long-lived pledge certificate][rfc8995#2.6.2].
+
+[rfc8995#2.6.2]: https://www.rfc-editor.org/rfc/rfc8995.html#name-infinite-lifetime-of-idevid
+
 #### Build
 
 * add `BUILD_JSMN` CMake option. Set this to `OFF` in case you want to use
   your system's [jsmn](https://github.com/zserge/jsmn) lib, instead of
   downloading it automatically.
+
+### Changed
+
+#### voucher
+
+**The voucher ABI has breaking changes**.
 
 ## [0.2.0] - 2023-03-27
 ### Added

--- a/src/voucher/crypto.h
+++ b/src/voucher/crypto.h
@@ -36,8 +36,23 @@ struct crypto_cert_meta {
    *
    * This is the number of seconds after the current for the certificate to
    * stop being valid (aka expire).
+   *
+   * Either this or #not_after_absolute must be set (not both).
    */
   long not_after;
+  /**
+   * Optional Certificate validity "Not After" string.
+   *
+   * This must be an ASN.1 GENERALIZEDTIME string, e.g. in format
+   * `YYYYMMDDHH[MM[SS[.fff]]]Z`.
+   *
+   * Either this or #not_after must be set (not both).
+
+   * Set to `"99991231235959Z"` for a [long-lived pledge certificate][1]
+   * [1]:
+   https://www.rfc-editor.org/rfc/rfc8995.html#name-infinite-lifetime-of-idevid
+   */
+  const char *not_after_absolute;
 
   /*
     Decoded key/value pairs:

--- a/src/voucher/crypto.h
+++ b/src/voucher/crypto.h
@@ -24,7 +24,19 @@ typedef void *CRYPTO_CERT;
 
 struct crypto_cert_meta {
   uint64_t serial_number;
+  /**
+   * Certificate validity "Not Before" offset.
+   *
+   * This is the number of seconds after the current time for the certificate
+   * to start being valid.
+   */
   long not_before;
+  /**
+   * Certificate validity "Not After" offset.
+   *
+   * This is the number of seconds after the current for the certificate to
+   * stop being valid (aka expire).
+   */
   long not_after;
 
   /*

--- a/tests/voucher/generate_test_certs.c
+++ b/tests/voucher/generate_test_certs.c
@@ -71,13 +71,14 @@ static void generate_idevid_certs(void **state) {
   // Generate ROOT CA for MASA
   idevid_ca_key.length = crypto_generate_eckey(&idevid_ca_key.array);
 
-  struct crypto_cert_meta idevid_ca_meta = {.serial_number = 1,
-                                            .not_before = 0,
-                                            .not_after = 1234567,
-                                            .issuer = NULL,
-                                            .subject = NULL,
-                                            .basic_constraints =
-                                                "critical,CA:TRUE"};
+  struct crypto_cert_meta idevid_ca_meta = {
+      .serial_number = 1,
+      .not_before = 0,
+      // Long-lived pledge CA cert
+      .not_after_absolute = "99991231235959Z",
+      .issuer = NULL,
+      .subject = NULL,
+      .basic_constraints = "critical,CA:TRUE"};
 
   idevid_ca_meta.issuer = init_keyvalue_list();
   idevid_ca_meta.subject = init_keyvalue_list();
@@ -96,7 +97,9 @@ static void generate_idevid_certs(void **state) {
   {
     struct crypto_cert_meta idev_meta = {.serial_number = 12345,
                                          .not_before = 0,
-                                         .not_after = 1234567,
+                                         // Long-lived pledge certificate
+                                         .not_after_absolute =
+                                             "99991231235959Z",
                                          .issuer = NULL,
                                          .subject = NULL,
                                          .basic_constraints = "CA:false"};

--- a/tests/voucher/generate_test_certs.c
+++ b/tests/voucher/generate_test_certs.c
@@ -19,6 +19,17 @@
 #include "voucher/crypto.h"
 #include "voucher/keyvalue.h"
 
+const long SECONDS_IN_YEAR = 10 * 60 * 60 * 24 * 365;
+
+// Default Root CA certificate "Not After" validity offset
+const long CA_NOT_AFTER = 10 * SECONDS_IN_YEAR;
+// Default Subordinate 1 CA certificate "Not After" validity offset
+const long CA1_NOT_AFTER = 5 * SECONDS_IN_YEAR;
+// Default Subordinate 2 CA certificate "Not After" validity offset
+const long CA2_NOT_AFTER = 2 * SECONDS_IN_YEAR;
+// Default end-entity certificate "Not After" validity offset
+const long END_ENTITY_NOT_AFTER = 13 * SECONDS_IN_YEAR / 12; // 13 months
+
 struct context {
   /** The folder to store the certs and keys in */
   const char *output_dir;
@@ -143,7 +154,7 @@ static void generate_ldevid_ca_cert(void **state) {
 
   struct crypto_cert_meta ldevid_ca_meta = {.serial_number = 1,
                                             .not_before = 0,
-                                            .not_after = 1234567,
+                                            .not_after = CA_NOT_AFTER,
                                             .issuer = NULL,
                                             .subject = NULL,
                                             .basic_constraints =
@@ -177,7 +188,7 @@ static void generate_masa_tls_certs(void **state) {
 
   struct crypto_cert_meta masa_tls_ca_meta = {.serial_number = 1,
                                               .not_before = 0,
-                                              .not_after = 1234567,
+                                              .not_after = CA_NOT_AFTER,
                                               .issuer = NULL,
                                               .subject = NULL,
                                               .basic_constraints =
@@ -205,7 +216,7 @@ static void generate_masa_tls_certs(void **state) {
   {
     struct crypto_cert_meta masa_tls_meta = {.serial_number = 12345,
                                              .not_before = 0,
-                                             .not_after = 1234567,
+                                             .not_after = END_ENTITY_NOT_AFTER,
                                              .issuer = NULL,
                                              .subject = NULL,
                                              .basic_constraints = "CA:false"};
@@ -249,7 +260,7 @@ static void generate_registrar_tls_certs(void **state) {
 
   struct crypto_cert_meta registrar_tls_ca_meta = {.serial_number = 1,
                                                    .not_before = 0,
-                                                   .not_after = 1234567,
+                                                   .not_after = CA_NOT_AFTER,
                                                    .issuer = NULL,
                                                    .subject = NULL,
                                                    .basic_constraints =
@@ -270,13 +281,13 @@ static void generate_registrar_tls_certs(void **state) {
       &registrar_tls_ca_meta, registrar_tls_ca_key.array,
       registrar_tls_ca_key.length, &registrar_tls_ca_cert.array);
 
-  struct crypto_cert_meta registrar_tls_meta = {.serial_number = 12345,
-                                                .not_before = 0,
-                                                .not_after = 1234567,
-                                                .issuer = NULL,
-                                                .subject = NULL,
-                                                .basic_constraints =
-                                                    "CA:false"};
+  struct crypto_cert_meta registrar_tls_meta = {
+      .serial_number = 12345,
+      .not_before = 0,
+      .not_after = END_ENTITY_NOT_AFTER,
+      .issuer = NULL,
+      .subject = NULL,
+      .basic_constraints = "CA:false"};
 
   registrar_tls_meta.issuer = init_keyvalue_list();
   registrar_tls_meta.subject = init_keyvalue_list();
@@ -351,7 +362,7 @@ static void generate_cms_certs(void **state) {
 
   struct crypto_cert_meta cms_ca_meta = {.serial_number = 1,
                                          .not_before = 0,
-                                         .not_after = 1234567,
+                                         .not_after = CA_NOT_AFTER,
                                          .issuer = NULL,
                                          .subject = NULL,
                                          .basic_constraints =
@@ -376,7 +387,7 @@ static void generate_cms_certs(void **state) {
   {
     struct crypto_cert_meta int2_cms_meta = {.serial_number = 12345,
                                              .not_before = 0,
-                                             .not_after = 1234567,
+                                             .not_after = CA1_NOT_AFTER,
                                              .issuer = NULL,
                                              .subject = NULL,
                                              .basic_constraints = "CA:false"};
@@ -407,7 +418,7 @@ static void generate_cms_certs(void **state) {
     {
       struct crypto_cert_meta int1_cms_meta = {.serial_number = 12345,
                                                .not_before = 0,
-                                               .not_after = 1234567,
+                                               .not_after = CA2_NOT_AFTER,
                                                .issuer = NULL,
                                                .subject = NULL,
                                                .basic_constraints = "CA:false"};
@@ -436,13 +447,13 @@ static void generate_cms_certs(void **state) {
           save_cert("int1-cms", context, &int1_cms_key, &int1_cms_cert), errno);
 
       {
-        struct crypto_cert_meta pledge_cms_meta = {.serial_number = 1,
-                                                   .not_before = 0,
-                                                   .not_after = 1234567,
-                                                   .issuer = NULL,
-                                                   .subject = NULL,
-                                                   .basic_constraints =
-                                                       "CA:false"};
+        struct crypto_cert_meta pledge_cms_meta = {
+            .serial_number = 1,
+            .not_before = 0,
+            .not_after = END_ENTITY_NOT_AFTER,
+            .issuer = NULL,
+            .subject = NULL,
+            .basic_constraints = "CA:false"};
 
         pledge_cms_meta.issuer = init_keyvalue_list();
         pledge_cms_meta.subject = init_keyvalue_list();
@@ -476,13 +487,13 @@ static void generate_cms_certs(void **state) {
       }
 
       {
-        struct crypto_cert_meta registrar_cms_meta = {.serial_number = 1,
-                                                      .not_before = 0,
-                                                      .not_after = 1234567,
-                                                      .issuer = NULL,
-                                                      .subject = NULL,
-                                                      .basic_constraints =
-                                                          "CA:false"};
+        struct crypto_cert_meta registrar_cms_meta = {
+            .serial_number = 1,
+            .not_before = 0,
+            .not_after = END_ENTITY_NOT_AFTER,
+            .issuer = NULL,
+            .subject = NULL,
+            .basic_constraints = "CA:false"};
 
         registrar_cms_meta.issuer = init_keyvalue_list();
         registrar_cms_meta.subject = init_keyvalue_list();
@@ -517,13 +528,13 @@ static void generate_cms_certs(void **state) {
       }
 
       {
-        struct crypto_cert_meta masa_cms_meta = {.serial_number = 1,
-                                                 .not_before = 0,
-                                                 .not_after = 1234567,
-                                                 .issuer = NULL,
-                                                 .subject = NULL,
-                                                 .basic_constraints =
-                                                     "CA:false"};
+        struct crypto_cert_meta masa_cms_meta = {
+            .serial_number = 1,
+            .not_before = 0,
+            .not_after = END_ENTITY_NOT_AFTER,
+            .issuer = NULL,
+            .subject = NULL,
+            .basic_constraints = "CA:false"};
 
         masa_cms_meta.issuer = init_keyvalue_list();
         masa_cms_meta.subject = init_keyvalue_list();


### PR DESCRIPTION
Add `not_after_absolute` field to `struct crypto_cert_meta`.

Unlike the existing `not_after` field, which represents an offset from the current time, the `not_after_absolute` field represents an ASN.1 GENERALIZEDTIME absolute time.

It can be set to `"99991231235959Z"` for a [BRSKI long-lived pledge certificate][rfc8995#2.6.2].

[rfc8995#2.6.2]: https://www.rfc-editor.org/rfc/rfc8995.html#name-infinite-lifetime-of-idevid

This PR will also update the validity period of the test certificates generated by `generate_test_certs` (I've followed the guidelines from https://docs.aws.amazon.com/privateca/latest/userguide/ca-lifecycle.html):

  - Root CA certs are valid for 10 years.
  - CA certs that are subordinate to the Root CA are valid for 5 years.
  - CA certs that are 2nd-level subordiante to the Root CA are valid
    for 2 years.
  - End-entity certs (e.g. the one used for TLS connections)
    are valid for 13 months.
  - IDevID certificates are [long-lived certificates][rfc8995#2.6.2].

**BREAKING CHANGE**: This is an ABI breaking change for the voucher lib.
