### PR TITLE
fix(brski): update pledge request (`preq`) docs

### DIFF
--- a/src/brski/brski.cpp
+++ b/src/brski/brski.cpp
@@ -44,7 +44,8 @@ const std::array<struct command_config, 4> command_list = {{
     {"epvr", CommandId::COMMAND_EXPORT_PVR,
      "\tepvr\t\tExport the pledge voucher request as base64 CMS file"},
     {"preq", CommandId::COMMAND_PLEDGE_REQUEST,
-     "\tpreq\t\tSend a pledge-voucher request to the registrar"},
+     "\tpreq\t\tSend a pledge-voucher request to the registrar and\n"
+     "\t\t\t return the pinned-domain-cert."},
     {"registrar", CommandId::COMMAND_START_REGISTRAR,
      "\tregistrar\tStarts the registrar"},
     {"masa", CommandId::COMMAND_START_MASA, "\tmasa\t\tStarts the MASA"},
@@ -217,7 +218,6 @@ int main(int argc, char *argv[]) {
 
   struct RegistrarContext *rcontext = NULL;
   struct MasaContext *mcontext = NULL;
-  std::string response;
   switch (command_id) {
     case CommandId::COMMAND_EXPORT_PVR:
       std::fprintf(stdout, "Exporting pledge voucher request to %s",
@@ -229,9 +229,10 @@ int main(int argc, char *argv[]) {
         return EXIT_FAILURE;
       }
       break;
-    case CommandId::COMMAND_PLEDGE_REQUEST:
+    case CommandId::COMMAND_PLEDGE_REQUEST: {
       std::fprintf(stdout, "Pledge voucher request to %s:%d\n",
                    config.rconf.bind_address, config.rconf.port);
+      std::string response;
       if (post_voucher_pledge_request(&config.pconf, &config.rconf,
                                       &config.mconf, response) < 0) {
         std::fprintf(stderr, "post_voucher_pledge_request fail");
@@ -239,6 +240,7 @@ int main(int argc, char *argv[]) {
       }
       std::fprintf(stdout, "%s\n", response.c_str());
       break;
+    }
     case CommandId::COMMAND_START_REGISTRAR:
       if (registrar_start(&config.rconf, &config.mconf, &config.pconf,
                           &rcontext) < 0) {

--- a/src/brski/pledge/pledge_request.h
+++ b/src/brski/pledge/pledge_request.h
@@ -23,7 +23,8 @@
  * @param[in] pconf The pledge configuration structure
  * @param[in] rconf The registrar configuration structure
  * @param[in] mconf The masa configuration structure
- * @param[out] response The response from the POST request
+ * @param[out] response The pinned domain certificate in DER format, encoded as
+ * base64.
  * @return int 0 on success, -1 on failure
  */
 int post_voucher_pledge_request(struct pledge_config *pconf,


### PR DESCRIPTION
State that `brski preq` returns the `pinned-domain-cert`. This change was made in d7d1c07 (feat: Added pinned domain cert output, 2023-05-16).

Fixes: d7d1c07abab4652adbea048cb4f00ceb80fa2abf