### PR TITLE
Remove autogenerated `compile_commands.json` file

### DIFF
--- a/compile_commands.json
+++ b/compile_commands.json
@@ -1,1 +1,0 @@
-/home/alexandru/projects/brski/build/linux/compile_commands.json


### PR DESCRIPTION
The `compile_commands.json` file is required by some Clang tools, see https://clang.llvm.org/docs/JSONCompilationDatabase.html.

However, this file is auto-generated by CMake when needed. In fact, the current `compile_commands.json` points to a file that doesn't exist on most PCs.

We've already got it in our `.gitignore` file, so it shouldn't get readded, see https://github.com/nqminds/brski/blob/ea11e49bd9875cd5421482fbdc0553a5143784b9/.gitignore#L38