### PR TITLE
fix(pledge_request): handle registrar HTTP errors

### DIFF
--- a/src/brski/pledge/pledge_request.cpp
+++ b/src/brski/pledge/pledge_request.cpp
@@ -75,8 +75,12 @@ int post_voucher_pledge_request(struct pledge_config *pconf,
     log_error("https_post_request fail");
     return -1;
   }
-
-  log_debug("post_voucher_pledge_request status %d", status);
+  if (status >= 400) {
+    log_error("post_voucher_pledge_request failed with HTTP code %d and "
+              "response: '%s'",
+              status, response.c_str());
+    return -1;
+  }
 
   const char *masa_pledge_voucher_str = response.c_str();
   struct BinaryArray masa_pledge_voucher_cms = {};


### PR DESCRIPTION
Currently, if making a POST request to `127.0.0.1:12345/.well-known/brski/requestvoucher`
(aka the registrar server), any requests that complete and return a HTTP error code cause the pledge to crash with a:

```
d2i_CMS_ContentInfo fail with code=error:0680007B:asn1` OpenSSL error
```

This is because the registrar sends an error response like "Router error", but the pledge code tries to parse it as a [CMS][1].

[1]: https://en.wikipedia.org/wiki/Cryptographic_Message_Syntax