### PR TITLE
Improve the `registrar_requestvoucher()` registrar API handler

### DIFF
--- a/src/brski/http/httplib_wrapper.cpp
+++ b/src/brski/http/httplib_wrapper.cpp
@@ -160,9 +160,11 @@ int httplib_register_routes(httplib::SSLServer *server,
 void set_error_handler(httplib::SSLServer *server) {
   server->set_error_handler(
       [](const httplib::Request &req, httplib::Response &res) {
-        char buf[BUFSIZ];
-        snprintf(buf, sizeof(buf), HTTP_ERROR_REPLY);
-        res.set_content(buf, "text/plain");
+        if (res.body == "") {
+          res.body = HTTP_ERROR_REPLY; // set default error response
+        }
+        // according to BRSKI spec, all errors must be plain text
+        res.set_header("Content-Type", "text/plain");
       });
 }
 

--- a/src/brski/registrar/registrar_api.cpp
+++ b/src/brski/registrar/registrar_api.cpp
@@ -228,6 +228,9 @@ int registrar_requestvoucher(const RequestHeader &request_header,
   if (post_voucher_request(voucher_request_cms.get(), mconf, rconf, response) <
       0) {
     log_error("post_voucher_request fail");
+    response.assign(
+        "Voucher request to the MASA server failed. Please contact the "
+        "webmaster of the registrar server if this error persists.");
     return 502;
   }
 

--- a/src/brski/registrar/registrar_api.cpp
+++ b/src/brski/registrar/registrar_api.cpp
@@ -7,6 +7,8 @@
  * SPDX-License-Identifier: MIT
  * @brief File containing the implementation of the registrar routes.
  */
+#include <functional>
+#include <memory>
 #include <string>
 
 #include "../http/http.h"
@@ -80,15 +82,6 @@ int registrar_requestvoucher(const RequestHeader &request_header,
   struct registrar_config *rconf = context->rconf;
   struct masa_config *mconf = context->mconf;
 
-  struct BinaryArray pledge_voucher_request_cms = {};
-  struct BinaryArray *idevid_issuer = NULL;
-  struct BinaryArray *registrar_tls_cert = NULL;
-  struct BinaryArray *registrar_sign_cert = NULL;
-  struct BinaryArray *registrar_sign_key = NULL;
-  struct BinaryArrayList *pledge_verify_certs = NULL;
-  struct BinaryArrayList *pledge_store_certs = NULL;
-  struct BinaryArrayList *additional_registrar_certs = NULL;
-  struct BinaryArray *voucher_request_cms = NULL;
   struct tm created_on = {0};
   char *serial_number = NULL;
   const char *cms_str = request_body.c_str();
@@ -96,100 +89,145 @@ int registrar_requestvoucher(const RequestHeader &request_header,
   log_trace("registrar_requestvoucher:");
   response_header["Content-Type"] = "application/voucher-cms+json";
 
-  struct crypto_cert_meta idev_meta = {};
-  idev_meta.issuer = init_keyvalue_list();
-  idev_meta.subject = init_keyvalue_list();
-
-  // The status_code to return
-  int status_code = 400;
+  struct CrypoCertMeta : public crypto_cert_meta {
+    CrypoCertMeta() {
+      this->issuer = init_keyvalue_list();
+      this->subject = init_keyvalue_list();
+    }
+    ~CrypoCertMeta() {
+      free_keyvalue_list(this->issuer);
+      free_keyvalue_list(this->subject);
+    }
+  } idev_meta;
 
   if (crypto_getcert_meta(peer_certificate, &idev_meta) < 0) {
     log_error("crypto_getcert_meta");
-    goto registrar_requestvoucher_fail;
+    return 400;
   }
 
   serial_number = get_cert_serial(&idev_meta);
 
-  if ((idevid_issuer = crypto_getcert_issuer(peer_certificate)) == NULL) {
+  auto idevid_issuer = std::unique_ptr<BinaryArray, void (*)(BinaryArray *)>{
+      crypto_getcert_issuer(peer_certificate),
+      [](BinaryArray *b) { free_binary_array(b); },
+  };
+  if (idevid_issuer == nullptr) {
     log_error("crypto_getcert_issuer fail");
-    goto registrar_requestvoucher_fail;
+    return 400;
   }
 
-  if ((pledge_voucher_request_cms.length =
+  auto pledge_voucher_request_cms =
+      std::unique_ptr<BinaryArray, void (*)(BinaryArray *)>{
+          static_cast<BinaryArray *>(std::malloc(sizeof(BinaryArray))),
+          [](BinaryArray *b) { free_binary_array(b); },
+      };
+  if ((pledge_voucher_request_cms->length =
            serialize_base64str2array((const uint8_t *)cms_str, strlen(cms_str),
-                                     &pledge_voucher_request_cms.array)) < 0) {
+                                     &pledge_voucher_request_cms->array)) < 0) {
     log_errno("serialize_base64str2array fail");
-    goto registrar_requestvoucher_fail;
+    return 400;
   }
 
   if (get_localtime(&created_on) < 0) {
     log_error("get_localtime fail");
-    goto registrar_requestvoucher_fail;
+    return 400;
   }
 
-  if ((registrar_tls_cert = file_to_x509buf(rconf->tls_cert_path)) == NULL) {
+  auto registrar_tls_cert =
+      std::unique_ptr<BinaryArray, void (*)(BinaryArray *)>{
+          file_to_x509buf(rconf->tls_cert_path),
+          [](BinaryArray *b) { free_binary_array(b); },
+      };
+  if (registrar_tls_cert == nullptr) {
     log_error("file_to_x509buf fail");
-    goto registrar_requestvoucher_fail;
+    return 400;
   }
 
-  if ((registrar_sign_cert = file_to_x509buf(rconf->cms_sign_cert_path)) ==
-      NULL) {
+  auto registrar_sign_cert =
+      std::unique_ptr<BinaryArray, void (*)(BinaryArray *)>{
+          file_to_x509buf(rconf->cms_sign_cert_path),
+          [](BinaryArray *b) { free_binary_array(b); },
+      };
+  if (registrar_sign_cert == nullptr) {
     log_error("file_to_x509buf fail");
-    goto registrar_requestvoucher_fail;
+    return 400;
   }
 
-  if ((registrar_sign_key = file_to_keybuf(rconf->cms_sign_key_path)) == NULL) {
+  auto registrar_sign_key =
+      std::unique_ptr<BinaryArray, void (*)(BinaryArray *)>{
+          file_to_keybuf(rconf->cms_sign_key_path),
+          [](BinaryArray *b) { free_binary_array(b); },
+      };
+  if (registrar_sign_key == nullptr) {
     log_error("file_to_keybuf fail");
-    goto registrar_requestvoucher_fail;
+    return 400;
   }
 
-  if (load_cert_files(rconf->cms_verify_certs_paths, &pledge_verify_certs) <
-      0) {
-    log_error("load_cert_files");
-    goto registrar_requestvoucher_fail;
+  auto pledge_verify_certs =
+      std::unique_ptr<BinaryArrayList, void (*)(BinaryArrayList *)>{
+          nullptr,
+          [](BinaryArrayList *list) { free_array_list(list); },
+      };
+  {
+    BinaryArrayList *ptr = nullptr;
+    if (load_cert_files(rconf->cms_verify_certs_paths, &ptr) < 0) {
+      log_error("load_cert_files");
+      return 400;
+    }
+    pledge_verify_certs.reset(ptr);
   }
 
-  if (load_cert_files(rconf->cms_verify_store_paths, &pledge_store_certs) < 0) {
-    log_error("load_cert_files");
-    goto registrar_requestvoucher_fail;
+  auto pledge_store_certs =
+      std::unique_ptr<BinaryArrayList, void (*)(BinaryArrayList *)>{
+          nullptr,
+          [](BinaryArrayList *list) { free_array_list(list); },
+      };
+  {
+    BinaryArrayList *ptr = nullptr;
+    if (load_cert_files(rconf->cms_verify_store_paths, &ptr) < 0) {
+      log_error("load_cert_files");
+      return 400;
+    }
+    pledge_store_certs.reset(ptr);
   }
 
-  if (load_cert_files(rconf->cms_add_certs_paths, &additional_registrar_certs) <
-      0) {
-    log_error("load_cert_files");
-    goto registrar_requestvoucher_fail;
+  auto additional_registrar_certs =
+      std::unique_ptr<BinaryArrayList, void (*)(BinaryArrayList *)>{
+          nullptr,
+          [](BinaryArrayList *list) { free_array_list(list); },
+      };
+  {
+    BinaryArrayList *ptr = nullptr;
+    if (load_cert_files(rconf->cms_add_certs_paths, &ptr) < 0) {
+      log_error("load_cert_files");
+      return 400;
+    }
+    additional_registrar_certs.reset(ptr);
   }
 
-  voucher_request_cms = sign_voucher_request(
-      &pledge_voucher_request_cms, &created_on, serial_number, idevid_issuer,
-      registrar_tls_cert, registrar_sign_cert, registrar_sign_key,
-      pledge_verify_certs, pledge_store_certs, additional_registrar_certs);
+  auto voucher_request_cms =
+      std::unique_ptr<BinaryArray, void (*)(BinaryArray *)>{
+          sign_voucher_request(
+              pledge_voucher_request_cms.get(), &created_on, serial_number,
+              idevid_issuer.get(), registrar_tls_cert.get(),
+              registrar_sign_cert.get(), registrar_sign_key.get(),
+              pledge_verify_certs.get(), pledge_store_certs.get(),
+              additional_registrar_certs.get()),
+          [](BinaryArray *b) { free_binary_array(b); },
+      };
 
-  if (voucher_request_cms == NULL) {
+  if (voucher_request_cms == nullptr) {
     log_error("sign_voucher_request fail");
-    goto registrar_requestvoucher_fail;
+    return 400;
   }
 
-  if (post_voucher_request(voucher_request_cms, mconf, rconf, response) < 0) {
+  if (post_voucher_request(voucher_request_cms.get(), mconf, rconf, response) <
+      0) {
     log_error("post_voucher_request fail");
-    goto registrar_requestvoucher_fail;
+    return 400;
   }
 
-  status_code = 200;
-
-registrar_requestvoucher_fail:
-  free_binary_array(registrar_tls_cert);
-  free_binary_array(registrar_sign_cert);
-  free_binary_array(registrar_sign_key);
-  free_array_list(pledge_verify_certs);
-  free_array_list(pledge_store_certs);
-  free_array_list(additional_registrar_certs);
-  free_binary_array(voucher_request_cms);
-  free_binary_array(idevid_issuer);
-  free_keyvalue_list(idev_meta.issuer);
-  free_keyvalue_list(idev_meta.subject);
-  free_binary_array_content(&pledge_voucher_request_cms);
-  return status_code;
+  return 200;
 }
 
 int registrar_voucher_status(const RequestHeader &request_header,

--- a/src/brski/registrar/registrar_api.cpp
+++ b/src/brski/registrar/registrar_api.cpp
@@ -100,6 +100,9 @@ int registrar_requestvoucher(const RequestHeader &request_header,
   idev_meta.issuer = init_keyvalue_list();
   idev_meta.subject = init_keyvalue_list();
 
+  // The status_code to return
+  int status_code = 400;
+
   if (crypto_getcert_meta(peer_certificate, &idev_meta) < 0) {
     log_error("crypto_getcert_meta");
     goto registrar_requestvoucher_fail;
@@ -172,18 +175,7 @@ int registrar_requestvoucher(const RequestHeader &request_header,
     goto registrar_requestvoucher_fail;
   }
 
-  free_binary_array(registrar_tls_cert);
-  free_binary_array(registrar_sign_cert);
-  free_binary_array(registrar_sign_key);
-  free_array_list(pledge_verify_certs);
-  free_array_list(pledge_store_certs);
-  free_array_list(additional_registrar_certs);
-  free_binary_array(voucher_request_cms);
-  free_binary_array(idevid_issuer);
-  free_keyvalue_list(idev_meta.issuer);
-  free_keyvalue_list(idev_meta.subject);
-  free_binary_array_content(&pledge_voucher_request_cms);
-  return 200;
+  status_code = 200;
 
 registrar_requestvoucher_fail:
   free_binary_array(registrar_tls_cert);
@@ -197,7 +189,7 @@ registrar_requestvoucher_fail:
   free_keyvalue_list(idev_meta.issuer);
   free_keyvalue_list(idev_meta.subject);
   free_binary_array_content(&pledge_voucher_request_cms);
-  return 400;
+  return status_code;
 }
 
 int registrar_voucher_status(const RequestHeader &request_header,

--- a/src/brski/registrar/registrar_api.cpp
+++ b/src/brski/registrar/registrar_api.cpp
@@ -9,6 +9,7 @@
  */
 #include <functional>
 #include <memory>
+#include <new>
 #include <string>
 
 #include "../http/http.h"
@@ -93,6 +94,9 @@ int registrar_requestvoucher(const RequestHeader &request_header,
     CrypoCertMeta() {
       this->issuer = init_keyvalue_list();
       this->subject = init_keyvalue_list();
+      if (this->issuer == nullptr || this->subject == nullptr) {
+        throw std::bad_alloc();
+      }
     }
     ~CrypoCertMeta() {
       free_keyvalue_list(this->issuer);

--- a/src/brski/registrar/registrar_api.cpp
+++ b/src/brski/registrar/registrar_api.cpp
@@ -134,7 +134,7 @@ int registrar_requestvoucher(const RequestHeader &request_header,
 
   if (get_localtime(&created_on) < 0) {
     log_error("get_localtime fail");
-    return 400;
+    return 500;
   }
 
   auto registrar_tls_cert =
@@ -144,7 +144,7 @@ int registrar_requestvoucher(const RequestHeader &request_header,
       };
   if (registrar_tls_cert == nullptr) {
     log_error("file_to_x509buf fail");
-    return 400;
+    return 500;
   }
 
   auto registrar_sign_cert =
@@ -154,7 +154,7 @@ int registrar_requestvoucher(const RequestHeader &request_header,
       };
   if (registrar_sign_cert == nullptr) {
     log_error("file_to_x509buf fail");
-    return 400;
+    return 500;
   }
 
   auto registrar_sign_key =
@@ -164,7 +164,7 @@ int registrar_requestvoucher(const RequestHeader &request_header,
       };
   if (registrar_sign_key == nullptr) {
     log_error("file_to_keybuf fail");
-    return 400;
+    return 500;
   }
 
   auto pledge_verify_certs =
@@ -176,7 +176,7 @@ int registrar_requestvoucher(const RequestHeader &request_header,
     BinaryArrayList *ptr = nullptr;
     if (load_cert_files(rconf->cms_verify_certs_paths, &ptr) < 0) {
       log_error("load_cert_files");
-      return 400;
+      return 500;
     }
     pledge_verify_certs.reset(ptr);
   }
@@ -190,7 +190,7 @@ int registrar_requestvoucher(const RequestHeader &request_header,
     BinaryArrayList *ptr = nullptr;
     if (load_cert_files(rconf->cms_verify_store_paths, &ptr) < 0) {
       log_error("load_cert_files");
-      return 400;
+      return 500;
     }
     pledge_store_certs.reset(ptr);
   }
@@ -204,7 +204,7 @@ int registrar_requestvoucher(const RequestHeader &request_header,
     BinaryArrayList *ptr = nullptr;
     if (load_cert_files(rconf->cms_add_certs_paths, &ptr) < 0) {
       log_error("load_cert_files");
-      return 400;
+      return 500;
     }
     additional_registrar_certs.reset(ptr);
   }
@@ -228,7 +228,7 @@ int registrar_requestvoucher(const RequestHeader &request_header,
   if (post_voucher_request(voucher_request_cms.get(), mconf, rconf, response) <
       0) {
     log_error("post_voucher_request fail");
-    return 400;
+    return 502;
   }
 
   return 200;

--- a/src/brski/registrar/registrar_api.h
+++ b/src/brski/registrar/registrar_api.h
@@ -18,7 +18,11 @@
 /**
  * @brief Registrar request voucher handler
  *
- * @return int 0 on success, -1 on failure
+ * @return The HTTP status code.
+ * @retval 200 OK.
+ * @retval 400 Bad Request (malformed request).
+ * @retval 500 Internal Server Error (e.g. invalid config).
+ * @retval 502 Bad Gateway (e.g. could not send requests to MASA server)
  */
 int registrar_requestvoucher(const RequestHeader &request_header,
                              const std::string &request_body,
@@ -29,7 +33,8 @@ int registrar_requestvoucher(const RequestHeader &request_header,
 /**
  * @brief Registrar voucher status handler
  *
- * @return int 0 on success, -1 on failure
+ * @return The HTTP status code.
+ * @retval 200 OK.
  */
 int registrar_voucher_status(const RequestHeader &request_header,
                              const std::string &request_body,
@@ -40,7 +45,8 @@ int registrar_voucher_status(const RequestHeader &request_header,
 /**
  * @brief Registrar request audit log handler
  *
- * @return int 0 on success, -1 on failure
+ * @return The HTTP status code.
+ * @retval 200 OK.
  */
 int registrar_requestauditlog(const RequestHeader &request_header,
                               const std::string &request_body,
@@ -51,7 +57,8 @@ int registrar_requestauditlog(const RequestHeader &request_header,
 /**
  * @brief Registrar enroll status handler
  *
- * @return int 0 on success, -1 on failure
+ * @return The HTTP status code.
+ * @retval 200 OK.
  */
 int registrar_enrollstatus(const RequestHeader &request_header,
                            const std::string &request_body,


### PR DESCRIPTION
Makes a couple of improvements to the `registrar_requestvoucher()` registrar API handler, aka the code that is called when calling `/.well-known/brski/requestvoucher` on the registrar server.

- Refactors the function to use RAII using C++ `std::unique_ptr` to automatically cleanup memory when the function exits. This allows us to use `return` instead of `goto`, and properly handles cleanup in case of C++ exceptions (7d80f95b6f9d6ce9f7b000d11c25f471a5cdddbc)
- Handles some potential NULL ptr dereferences (fcb161744634c28772c80ea88b9cb2726df6bb51)
- Improve the HTTP error codes in `registrar_requestvoucher()` (c53d10ff7a07ec04589b7181856bf33cf38abdc5 and ccc98d10a52c8911bccb09a57090ef95d6b51fab).
  - Previously, calling `/.well-known/brski/requestvoucher` would only return a HTTP 400 code on errors. Now, HTTP 500 (generic server error) or HTTP 502 (registrar server could not communicate with MASA server) error codes are returned when suitable.
