### PR TITLE
Use GitHub Actions default Azure apt mirror to install dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,14 +79,6 @@ jobs:
         # Sometimes the cache step just freezes forever
         # so put a limit on it so that we can restart it earlier on failure
         timeout-minutes: 10
-      - name: Set apt mirror
-        # GitHub Actions apt proxy is super unstable
-        # see https://github.com/actions/runner-images/issues/7048
-        run: |
-          # make sure there is a `\t` between URL and `priority:*` attributes
-          printf 'http://azure.archive.ubuntu.com/ubuntu        priority:1\n' | sudo tee /etc/apt/mirrors.txt
-          curl http://mirrors.ubuntu.com/mirrors.txt | sudo tee --append /etc/apt/mirrors.txt
-          sudo sed -i 's/http:\/\/azure.archive.ubuntu.com\/ubuntu\//mirror+file:\/etc\/apt\/mirrors.txt/' /etc/apt/sources.list
       - name: Install dependencies
         run: |
           sudo apt-get update && sudo apt-get install pbuilder debhelper -y


### PR DESCRIPTION
A lot of our CI jobs are timing out after 6 hours, due to slow mirrors.

For example, see:
  - https://github.com/nqminds/brski/actions/runs/5258181690/jobs/9569403505

It looks like Microsoft's Azure's Apt mirror is a bit more stable, so we can try using that one instead.