### PR TITLE
Add `init_binary_array()` function to fix `-Wmismatched-dealloc` warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * brski tool to demonstrate the Registrar and MASA functionalities
 
+#### voucher
+
+* add `init_binary_array()`, which initializes a new empty `struct BinaryArray`.
+
 #### Build
 
 * add `BUILD_JSMN` CMake option. Set this to `OFF` in case you want to use

--- a/src/brski/pledge/pledge_request.cpp
+++ b/src/brski/pledge/pledge_request.cpp
@@ -100,9 +100,8 @@ int post_voucher_pledge_request(struct pledge_config *pconf,
   }
 
   if (pconf->nonce != NULL) {
-    if ((nonce = (struct BinaryArray *)sys_zalloc(
-             sizeof(struct BinaryArray))) == NULL) {
-      log_errno("sys_zalloc");
+    if ((nonce = init_binary_array()) == NULL) {
+      log_errno("init_binary_array");
       goto post_voucher_pledge_request_fail;
     }
     ssize_t length;

--- a/src/brski/pledge/pledge_utils.c
+++ b/src/brski/pledge/pledge_utils.c
@@ -48,9 +48,9 @@ voucher_pledge_request_to_array(const struct pledge_config *pconf,
 
   struct BinaryArray *nonce = NULL;
   if (pconf->nonce != NULL) {
-    if ((nonce = (struct BinaryArray *)sys_zalloc(
-             sizeof(struct BinaryArray))) == NULL) {
-      log_errno("sys_zalloc");
+    nonce = init_binary_array();
+    if (nonce == NULL) {
+      log_errno("init_binary_array");
       return NULL;
     }
     ssize_t length;

--- a/src/voucher/array.c
+++ b/src/voucher/array.c
@@ -87,6 +87,16 @@ int push_array_list(struct BinaryArrayList *arr_list, uint8_t *const arr,
   return 0;
 }
 
+struct BinaryArray *init_binary_array(void) {
+  struct BinaryArray *binary_array = sys_malloc(sizeof(struct BinaryArrayList));
+  if (binary_array == NULL) {
+    log_errno("sys_malloc");
+    return NULL;
+  }
+  *binary_array = (struct BinaryArray){.array = NULL, .length = 0};
+  return binary_array;
+}
+
 int copy_binary_array(struct BinaryArray *const dst,
                       const struct BinaryArray *src) {
   if (dst == NULL) {

--- a/src/voucher/array.h
+++ b/src/voucher/array.h
@@ -189,6 +189,14 @@ void free_binary_array(struct BinaryArray *arr);
 #endif /* __GNUC__ >= 11 */
 
 /**
+ * @brief Initializes a new empty binary array.
+ *
+ * @return Initialized binary array that must be deallocated with
+ * free_binary_array(), or `NULL` on failure.
+ */
+__must_free_binary_array struct BinaryArray *init_binary_array(void);
+
+/**
  * @brief Compare two binary arrays
  *
  * @param[in] src The source binary array

--- a/src/voucher/crypto_ossl.c
+++ b/src/voucher/crypto_ossl.c
@@ -272,10 +272,9 @@ struct BinaryArray *file_to_x509buf(const char *filename) {
   }
   fclose(fp);
 
-  struct BinaryArray *cert = sys_zalloc(sizeof(struct BinaryArray));
-
+  struct BinaryArray *cert = init_binary_array();
   if (cert == NULL) {
-    log_errno("sys_zalloc");
+    log_errno("init_binary_array");
     X509_free(x509);
     return NULL;
   }
@@ -310,10 +309,9 @@ struct BinaryArray *file_to_keybuf(const char *filename) {
   }
   fclose(fp);
 
-  struct BinaryArray *key = sys_zalloc(sizeof(struct BinaryArray));
-
+  struct BinaryArray *key = init_binary_array();
   if (key == NULL) {
-    log_errno("sys_zalloc");
+    log_errno("init_binary_array");
     EVP_PKEY_free(pkey);
     return NULL;
   }
@@ -393,9 +391,9 @@ struct BinaryArray *crypto_generate_rsakey(const int bits) {
   EVP_PKEY_CTX *ctx;
   EVP_PKEY *pkey = NULL;
 
-  struct BinaryArray *key = sys_zalloc(sizeof(struct BinaryArray));
+  struct BinaryArray *key = init_binary_array();
   if (key == NULL) {
-    log_errno("sys_zalloc");
+    log_errno("init_binary_array");
     return NULL;
   }
 
@@ -682,10 +680,10 @@ struct BinaryArray *crypto_getcert_issuer(CRYPTO_CERT cert) {
     return NULL;
   }
 
-  struct BinaryArray *issuer_array = sys_zalloc(sizeof(struct BinaryArray));
+  struct BinaryArray *issuer_array = init_binary_array();
 
   if (issuer_array == NULL) {
-    log_errno("sys_zalloc");
+    log_errno("init_binary_array");
     BIO_free(mem_data);
     return NULL;
   }

--- a/src/voucher/voucher.c
+++ b/src/voucher/voucher.c
@@ -899,28 +899,25 @@ struct BinaryArray *sign_eccms_voucher(struct Voucher *voucher,
     return NULL;
   }
 
-  uint8_t *cms = NULL;
-  ssize_t cms_length =
-      crypto_sign_eccms((uint8_t *)serialized, strlen(serialized), cert->array,
-                        cert->length, key->array, key->length, certs, &cms);
-
-  if (cms_length < 0) {
-    log_error("crypto_sign_eccms fail");
+  struct BinaryArray *cms = init_binary_array();
+  if (cms == NULL) {
+    log_errno("init_binary_array");
     sys_free(serialized);
     return NULL;
   }
+  ssize_t cms_length = crypto_sign_eccms(
+      (uint8_t *)serialized, strlen(serialized), cert->array, cert->length,
+      key->array, key->length, certs, &cms->array);
+
   sys_free(serialized);
-
-  struct BinaryArray *out = sys_malloc(sizeof(struct BinaryArray));
-  if (out == NULL) {
-    log_errno("sys_malloc");
-    sys_free(cms);
+  if (cms_length < 0) {
+    log_error("crypto_sign_eccms fail");
+    free_binary_array(cms);
     return NULL;
+  } else {
+    cms->length = cms_length;
   }
-
-  out->array = cms;
-  out->length = cms_length;
-  return out;
+  return cms;
 }
 
 struct BinaryArray *sign_rsacms_voucher(struct Voucher *voucher,
@@ -949,28 +946,25 @@ struct BinaryArray *sign_rsacms_voucher(struct Voucher *voucher,
     return NULL;
   }
 
-  uint8_t *cms = NULL;
-  ssize_t cms_length =
-      crypto_sign_rsacms((uint8_t *)serialized, strlen(serialized), cert->array,
-                         cert->length, key->array, key->length, certs, &cms);
-
-  if (cms_length < 0) {
-    log_error("crypto_sign_eccms fail");
+  struct BinaryArray *cms = init_binary_array();
+  if (cms == NULL) {
+    log_errno("init_binary_array");
     sys_free(serialized);
     return NULL;
   }
+  ssize_t cms_length = crypto_sign_rsacms(
+      (uint8_t *)serialized, strlen(serialized), cert->array, cert->length,
+      key->array, key->length, certs, &cms->array);
+
   sys_free(serialized);
-
-  struct BinaryArray *out = sys_malloc(sizeof(struct BinaryArray));
-  if (out == NULL) {
-    log_errno("sys_malloc");
-    sys_free(cms);
+  if (cms_length < 0) {
+    log_error("crypto_sign_rsacms fail");
+    free_binary_array(cms);
     return NULL;
+  } else {
+    cms->length = cms_length;
   }
-
-  out->array = cms;
-  out->length = cms_length;
-  return out;
+  return cms;
 }
 
 __must_sys_free struct BinaryArray *
@@ -999,28 +993,25 @@ sign_cms_voucher(struct Voucher *voucher, const struct BinaryArray *cert,
     return NULL;
   }
 
-  uint8_t *cms = NULL;
-  ssize_t cms_length =
-      crypto_sign_cms((uint8_t *)serialized, strlen(serialized), cert->array,
-                      cert->length, key->array, key->length, certs, &cms);
-
-  if (cms_length < 0) {
-    log_error("crypto_sign_eccms fail");
+  struct BinaryArray *cms = init_binary_array();
+  if (cms == NULL) {
+    log_errno("init_binary_array");
     sys_free(serialized);
     return NULL;
   }
+  ssize_t cms_length = crypto_sign_cms(
+      (uint8_t *)serialized, strlen(serialized), cert->array, cert->length,
+      key->array, key->length, certs, &cms->array);
+
   sys_free(serialized);
-
-  struct BinaryArray *out = sys_malloc(sizeof(struct BinaryArray));
-  if (out == NULL) {
-    log_errno("sys_malloc");
-    sys_free(cms);
+  if (cms_length < 0) {
+    log_error("crypto_sign_cms fail");
+    free_binary_array(cms);
     return NULL;
+  } else {
+    cms->length = cms_length;
   }
-
-  out->array = cms;
-  out->length = cms_length;
-  return out;
+  return cms;
 }
 
 struct Voucher *verify_cms_voucher(const struct BinaryArray *cms,


### PR DESCRIPTION
Add the `init_binary_array()` function, which allocates and initializes a new empty `struct BinaryArray`.

Currently, allocation and initialization of an empty `struct BinaryArray` is done with `sys_zalloc(sizeof(struct BinaryArray))`. However, this has two issues, which are fixed with the `init_binary_array()` function:

1. Although zero-allocation of `struct BinaryArray` happens to work for current implementation of `struct BinaryArray` on x86_64, other platforms have `NULL` pointers that do not consist of just 0-bytes.
2. The current codebase under GCC 11.2.0 prints a `-Wmismatched-dealloc` warning when using `free_binary_array()` on structures created directly by `sys_zalloc`:

```
/build/brski-0.2.0/src/voucher/crypto_ossl.c: In function 'file_to_x509buf':
/build/brski-0.2.0/src/voucher/crypto_ossl.c:287:5: warning: 'free_binary_array' called on pointer returned from a mismatched allocation function [-Wmismatched-dealloc]
  287 |     free_binary_array(cert);
      |     ^~~~~~~~~~~~~~~~~~~~~~~
```