### PR TITLE
Replace deprecated `set-output` GitHub Actions command

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
           preset='${{ matrix.cmake-preset }}'
           # replace `/` with `-`
           escaped_preset="${preset////-}"
-          echo "::set-output name=ESCAPED_CMAKE_PRESET::${escaped_preset}"
+          echo "ESCAPED_CMAKE_PRESET=${escaped_preset}" >> "$GITHUB_OUTPUT"
       - name: Archive Install Output
         uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
[GitHub has deprecated the `set-output` command in GitHub Actions][1].

It was even targeted to be removed on 1st June 2023, but they've [postponed removal][2], since there are still a high amount of actions using this syntax. Nevertheless, we should still remove it before GitHub removes it and fails our actions.

[1]: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
[2]: https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/