### PR TITLE
add: random serial_number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### 🚀 Features
 
 * Added certificate serial number logging. By default the registrar logs to `/var/log/brski-registrar.log`.
-  
+
 #### voucher
 
 #### Build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [0.2.5] - 2024-1-24
+
+### 🚀 Features
+
+* Added certificate serial number logging. By default the registrar logs to `/var/log/brski-registrar.log`.
+  
+#### voucher
+
+#### Build
+
+### Changed
+
+#### voucher
+
 ## [0.2.4] - 2024-1-23
 
 ### 🚀 Features

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.14.0) # required for FindSQLite3
 cmake_policy(VERSION 3.14.0...3.24.0)
 
 project(BRSKI
-  VERSION 0.2.4
+  VERSION 0.2.5
   HOMEPAGE_URL "https://github.com/nqminds/brski"
   DESCRIPTION "Bootstrapping Remote Secure Key Infrastructure (BRSKI)"
   LANGUAGES C CXX

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-brski (0.2.4) UNRELEASED; urgency=low
+brski (0.2.5) UNRELEASED; urgency=low
 
   * Initial release
 

--- a/src/brski/pledge/pledge_request.cpp
+++ b/src/brski/pledge/pledge_request.cpp
@@ -192,14 +192,13 @@ std::string create_cert_string(const char *cert) {
   return out;
 }
 
-uint64_t gen_rand64(void)
-{
+uint64_t gen_rand64(void) {
   uint64_t value = 0x0;
 
   srand(time(0));
-  
-  for (int i=0; i<64; i += 15) {
-    value = value*((uint64_t)RAND_MAX + 1) + rand();
+
+  for (int i = 0; i < 64; i += 15) {
+    value = value * ((uint64_t)RAND_MAX + 1) + rand();
   }
   return value;
 }
@@ -209,7 +208,7 @@ int generate_sign_cert(struct BinaryArray *scert_cert,
   uint8_t rand[8];
   char rands[17];
   struct BinaryArray buf = {.array = rand, .length = 8};
-  
+
   struct crypto_cert_meta sign_cert_meta = {
       .serial_number = gen_rand64(),
       .not_before = 0,
@@ -218,7 +217,7 @@ int generate_sign_cert(struct BinaryArray *scert_cert,
       .issuer = NULL,
       .subject = NULL,
       .basic_constraints = (char *)"CA:false"};
-  
+
   if (crypto_getrand(&buf) < 0) {
     log_error("crypto_getrand fail");
     return -1;

--- a/src/brski/pledge/pledge_request.cpp
+++ b/src/brski/pledge/pledge_request.cpp
@@ -192,16 +192,26 @@ std::string create_cert_string(const char *cert) {
   return out;
 }
 
+uint64_t gen_rand64(void)
+{
+  uint64_t value = 0x0;
+
+  srand(time(0));
+  
+  for (int i=0; i<64; i += 15) {
+    value = value*((uint64_t)RAND_MAX + 1) + rand();
+  }
+  return value;
+}
+
 int generate_sign_cert(struct BinaryArray *scert_cert,
                        struct BinaryArray *scert_key) {
   uint8_t rand[8];
-  uint8_t serial_number_rand[8];
   char rands[17];
   struct BinaryArray buf = {.array = rand, .length = 8};
-  struct BinaryArray serial_buf = {.array = serial_number_rand, .length = 8};
   
   struct crypto_cert_meta sign_cert_meta = {
-      .serial_number = (uint64_t)serial_number_rand,
+      .serial_number = gen_rand64(),
       .not_before = 0,
       // Long-lived pledge certificate
       .not_after_absolute = (char *)"99991231235959Z",
@@ -209,11 +219,6 @@ int generate_sign_cert(struct BinaryArray *scert_cert,
       .subject = NULL,
       .basic_constraints = (char *)"CA:false"};
   
-  if (crypto_getrand(&serial_buf) < 0) {
-    log_error("crypto_getrand for serial number fail");
-    return -1;
-  }
-
   if (crypto_getrand(&buf) < 0) {
     log_error("crypto_getrand fail");
     return -1;

--- a/src/brski/pledge/pledge_request.cpp
+++ b/src/brski/pledge/pledge_request.cpp
@@ -195,17 +195,24 @@ std::string create_cert_string(const char *cert) {
 int generate_sign_cert(struct BinaryArray *scert_cert,
                        struct BinaryArray *scert_key) {
   uint8_t rand[8];
+  uint8_t serial_number_rand[8];
   char rands[17];
   struct BinaryArray buf = {.array = rand, .length = 8};
-
+  struct BinaryArray serial_buf = {.array = serial_number_rand, .length = 8};
+  
   struct crypto_cert_meta sign_cert_meta = {
-      .serial_number = 12345,
+      .serial_number = (uint64_t)serial_number_rand,
       .not_before = 0,
       // Long-lived pledge certificate
       .not_after_absolute = (char *)"99991231235959Z",
       .issuer = NULL,
       .subject = NULL,
       .basic_constraints = (char *)"CA:false"};
+  
+  if (crypto_getrand(&serial_buf) < 0) {
+    log_error("crypto_getrand for serial number fail");
+    return -1;
+  }
 
   if (crypto_getrand(&buf) < 0) {
     log_error("crypto_getrand fail");

--- a/src/brski/registrar/registrar_api.cpp
+++ b/src/brski/registrar/registrar_api.cpp
@@ -28,6 +28,66 @@ extern "C" {
 #include "../config.h"
 }
 
+void save_to_log(CRYPTO_CERT icert, CRYPTO_CERT lcert, char *log_path)
+{
+  struct crypto_cert_meta imeta = {};
+  imeta.issuer = init_keyvalue_list();
+  imeta.subject = init_keyvalue_list();
+
+  log_trace("Saving the log");
+
+  if (imeta.issuer == NULL || imeta.subject == NULL) {
+    log_error("error allocation metadata");
+    return;
+  }
+
+  if (crypto_getcert_meta(icert, &imeta) < 0) {
+    log_error("crypto_getcert_meta fail");
+    free_keyvalue_list(imeta.issuer);
+    free_keyvalue_list(imeta.subject);
+    return;
+  }
+
+  char *iserial = crypto_getcert_serial(&imeta);
+
+  struct crypto_cert_meta lmeta = {};
+  lmeta.issuer = init_keyvalue_list();
+  lmeta.subject = init_keyvalue_list();
+
+  if (lmeta.issuer == NULL || lmeta.subject == NULL) {
+    log_error("error allocation metadata");
+    free_keyvalue_list(imeta.issuer);
+    free_keyvalue_list(imeta.subject);
+    return;
+  }
+
+  if (crypto_getcert_meta(lcert, &lmeta) < 0) {
+    log_error("crypto_getcert_meta fail");
+    free_keyvalue_list(imeta.issuer);
+    free_keyvalue_list(imeta.subject);
+    free_keyvalue_list(lmeta.issuer);
+    free_keyvalue_list(lmeta.subject);
+    return;
+  }
+
+  char *lserial = crypto_getcert_serial(&lmeta);
+
+  FILE *f = fopen(log_path, "a");
+  if (f != NULL) {
+    fprintf(f, "%lu 0x%" PRIx64 " \"%s\" 0x%"  PRIx64 " \"%s\"\n", time(NULL), imeta.serial_number,
+      (iserial != NULL) ? iserial : "NULL", lmeta.serial_number,
+      (lserial != NULL) ? lserial : "NULL");
+    fclose(f);
+  } else {
+    log_errno("fopen fail");
+  }
+
+  free_keyvalue_list(imeta.issuer);
+  free_keyvalue_list(imeta.subject);
+  free_keyvalue_list(lmeta.issuer);
+  free_keyvalue_list(lmeta.subject);
+}
+
 int post_voucher_request(struct BinaryArray *voucher_request_cms,
                          struct masa_config *mconf,
                          struct registrar_config *rconf,
@@ -306,6 +366,7 @@ int registrar_est_simpleenroll(const RequestHeader &request_header,
   struct BinaryArray *tls_ca_key = NULL;
   struct BinaryArray *tls_ca_cert = NULL;
   ssize_t length;
+  CRYPTO_CERT scert;
 
   log_trace("registrar_est_simpleenroll:");
 
@@ -350,6 +411,14 @@ int registrar_est_simpleenroll(const RequestHeader &request_header,
   }
 
   response.assign((char *)cert_str);
+
+  scert = crypto_cert2context(cert_to_sign.array, cert_to_sign.length);
+
+  if (scert != NULL) {
+    save_to_log(peer_certificate, scert, context->log_path);
+    crypto_free_certcontext(scert);
+  }
+
 
   sys_free(cert_str);
   free_binary_array_content(&cert_to_sign);

--- a/src/brski/registrar/registrar_api.cpp
+++ b/src/brski/registrar/registrar_api.cpp
@@ -28,8 +28,7 @@ extern "C" {
 #include "../config.h"
 }
 
-void save_to_log(CRYPTO_CERT icert, CRYPTO_CERT lcert, char *log_path)
-{
+void save_to_log(CRYPTO_CERT icert, CRYPTO_CERT lcert, char *log_path) {
   struct crypto_cert_meta imeta = {};
   imeta.issuer = init_keyvalue_list();
   imeta.subject = init_keyvalue_list();
@@ -74,9 +73,9 @@ void save_to_log(CRYPTO_CERT icert, CRYPTO_CERT lcert, char *log_path)
 
   FILE *f = fopen(log_path, "a");
   if (f != NULL) {
-    fprintf(f, "%lu 0x%" PRIx64 " \"%s\" 0x%"  PRIx64 " \"%s\"\n", time(NULL), imeta.serial_number,
-      (iserial != NULL) ? iserial : "NULL", lmeta.serial_number,
-      (lserial != NULL) ? lserial : "NULL");
+    fprintf(f, "%lu 0x%" PRIx64 " \"%s\" 0x%" PRIx64 " \"%s\"\n", time(NULL),
+            imeta.serial_number, (iserial != NULL) ? iserial : "NULL",
+            lmeta.serial_number, (lserial != NULL) ? lserial : "NULL");
     fclose(f);
   } else {
     log_errno("fopen fail");
@@ -418,7 +417,6 @@ int registrar_est_simpleenroll(const RequestHeader &request_header,
     save_to_log(peer_certificate, scert, context->log_path);
     crypto_free_certcontext(scert);
   }
-
 
   sys_free(cert_str);
   free_binary_array_content(&cert_to_sign);

--- a/src/brski/registrar/registrar_config.h
+++ b/src/brski/registrar/registrar_config.h
@@ -29,6 +29,7 @@ struct RegistrarContext {
   struct registrar_config *rconf;
   struct masa_config *mconf;
   void *srv_ctx;
+  char log_path[255];
 };
 
 #endif

--- a/src/brski/registrar/registrar_server.cpp
+++ b/src/brski/registrar/registrar_server.cpp
@@ -21,6 +21,8 @@ extern "C" {
 #include "registrar_config.h"
 #include "registrar_server.hpp"
 
+#define LOG_PATH "/var/log/brski-registrar.log"
+
 void setup_registrar_routes(std::vector<struct RouteTuple> &routes) {
   routes.push_back({.path = std::string(PATH_BRSKI_REQUESTVOUCHER),
                     .method = HTTP_METHOD_POST,
@@ -53,6 +55,7 @@ int registrar_start(struct registrar_config *rconf, struct masa_config *mconf,
     *context = new RegistrarContext();
     (*context)->rconf = rconf;
     (*context)->mconf = mconf;
+    sys_strlcpy((*context)->log_path, LOG_PATH, 255);
   } catch (...) {
     log_error("failed to allocate RegistrarContext");
     return -1;

--- a/src/voucher/crypto.h
+++ b/src/voucher/crypto.h
@@ -219,7 +219,7 @@ CRYPTO_KEY crypto_key2context(const uint8_t *key, const size_t length);
  *
  * Caller is responsible for freeing the certificate context
  *
- * @param[in] key The input certirficate buffer (DER format)
+ * @param[in] key The input certificate buffer (DER format)
  * @param[in] length The certificate buffer length
  * @return CRYPTO_CERT certificate context, NULL on failure
  */

--- a/src/voucher/crypto_ossl.c
+++ b/src/voucher/crypto_ossl.c
@@ -712,7 +712,7 @@ int crypto_getcert_meta(CRYPTO_CERT cert, struct crypto_cert_meta *meta) {
   } else {
     if (!ASN1_INTEGER_get_uint64(&meta->serial_number, asn1_serial)) {
       log_error("ASN1_INTEGER_get_uint64 fail with code=%s",
-              ERR_error_string(ERR_get_error(), NULL));
+                ERR_error_string(ERR_get_error(), NULL));
     }
   }
 

--- a/src/voucher/crypto_ossl.c
+++ b/src/voucher/crypto_ossl.c
@@ -691,6 +691,7 @@ int get_x509_keyvalue(X509_NAME *name, struct keyvalue_list *list) {
 
 int crypto_getcert_meta(CRYPTO_CERT cert, struct crypto_cert_meta *meta) {
   X509 *x509 = (X509 *)cert;
+  ASN1_INTEGER *asn1_serial = NULL;
 
   if (cert == NULL) {
     log_error("cert param is NULL");
@@ -700,6 +701,19 @@ int crypto_getcert_meta(CRYPTO_CERT cert, struct crypto_cert_meta *meta) {
   if (meta == NULL) {
     log_error("meta param is NULL");
     return -1;
+  }
+
+  meta->serial_number = 0;
+
+  asn1_serial = X509_get_serialNumber(x509);
+  if (asn1_serial == NULL) {
+    log_error("X509_get_serialNumber fail with code=%s",
+              ERR_error_string(ERR_get_error(), NULL));
+  } else {
+    if (!ASN1_INTEGER_get_uint64(&meta->serial_number, asn1_serial)) {
+      log_error("ASN1_INTEGER_get_uint64 fail with code=%s",
+              ERR_error_string(ERR_get_error(), NULL));
+    }
   }
 
   X509_NAME *issuer = X509_get_issuer_name(x509);


### PR DESCRIPTION
This generates new eap-tls-client.crt certificates with a random serial_number.

`openssl x509 -in ./build/linux/tests/brski-test-certs/eap-tls-client.crt -serial -noout 
serial=7FFF9FFBE9C8`

However when I  moved the certificates eap-tls-client.crt eap-tls-client.key and tried to connect to the registrar-tls-ca access point on the registrar pi I am facing a decryption error. The registrar is not able to decrypt the certificate.

I have installed the newly generated debian (`https://github.com/nqminds/brski/actions/runs/7642113865/artifacts/1192047936)` on the pledge  and works. I can connect to the registrar using the new certificate. 